### PR TITLE
Implement conditions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16.0)
 
 project(kwin_gestures)
-set(PROJECT_VERSION "0.1.0")
+set(PROJECT_VERSION "0.2.0")
 
 set(KF_MIN_VERSION "5.240.0")
 set(QT_MIN_VERSION "6.6.0")

--- a/README.md
+++ b/README.md
@@ -115,14 +115,13 @@ Run ``qdbus org.kde.KWin /Effects org.kde.kwin.Effects.reconfigureEffect kwin_ge
 
 - **[Gestures]**
   - **[$Device]** (enum) - Which device to add this gesture for (``Touchpad``).<br>
-    - **[$Gesture]** (string) - Unique name for the gesture.
+    - **[$GestureId]** (int) - Unique ID for the gesture.
       - **Type** (enum) - ``Hold``, ``Pinch``, ``Swipe``
       - **Fingers** (int) - Number of fingers required to trigger this gesture.<br>Sets **MinimumFingers** and **MaximumFingers**.<br>Minimum value: **2** for hold and pinch gestures, **3** for swipe.<br>Default: **none** 
       - **MinimumFingers** (int) - Minimum number of fingers required to trigger this gesture.<br>See **Fingers** for accepted values.<br>Default: **none**
       - **MaximumFingers** (int) - Maximum number of fingers required to trigger this gesture.<br>See **Fingers** for accepted values.<br>Default: **none**
       - **TriggerWhenThresholdReached** (bool) - Whether to trigger the gesture immediately after the specified threshold is reached.<br>Default: **false**
-      - **TriggerOneActionOnly** (bool) - Whether to trigger only the first action that satisfies a condition.<br>Default: **false**
-      - **BlockBuiltInGesture** (bool) - Whether to block the built-in gesture if this one isn't triggered due to unsatisfied conditions.<br>Default: **true**<br>&nbsp;
+      - **TriggerOneActionOnly** (bool) - Whether to trigger only the first action that satisfies a condition.<br>Default: **false**<br>&nbsp;
       - **[Hold]** - Configuration for hold gestures.
         - **Threshold** (int) - In milliseconds.<br>Default: **0**
       - **[Pinch]** - Configuration for pinch gestures.
@@ -132,13 +131,13 @@ Run ``qdbus org.kde.KWin /Effects org.kde.kwin.Effects.reconfigureEffect kwin_ge
         - **Direction** (enum) - ``Left``, ``Right``, ``Up``, ``Down``
         - **ThresholdX** (int) - Threshold for the X axis in pixels.<br>Only used if **Direction** is ``Left`` or ``Right``.<br>Default: **0**
         - **ThresholdY** (int) - Threshold for the Y axis in pixels.<br>Only used if **Direction** is ``Up`` or ``Down``.<br>Default: **0**<br>&nbsp;
-      - **[Conditions]**
-        - **[$Condition]** (string) - Unique name for this condition.
-          - **Negate** (bool) - If true, this condition will be satisfied only when none of the specified properties are.<br>Default: **false**
+      - **[Conditions]** - At least one condition (or 0 if none specified) must be satisfied in order for this gesture to be triggered.
+        - **[$ConditionId]** (int) - Unique ID for this condition.
+          - **Negate** (bool) - If true, this condition will be satisfied only when none of its specified properties are.<br>Default: **false**
           - **WindowClassRegex** (string) - A regular expression executed on the currently focused window's resource class and resource name. If a match is not found for either, the condition will not be satisfied.<br>Default: **none**
           - **WindowState** (enum) - ``Fullscreen``, ``Maximized``. Values can be combined using the | separator, For example, ``Fullscreen|Maximized`` will match either fullscreen or maximized windows.<br>Default: **none**<br>&nbsp;
       - **[Actions]** - What do to when the gesture is triggered. Actions are executed in order as they appear in the configuration file.
-        - **[$Action]** (string) - Unique name for the action.
+        - **[$ActionId]** (int) - Unique ID for this action.
           - **Type** (enum)
             - ``Command`` - Run a command.
             - ``GlobalShortcut`` - Invoke a global shortcut.
@@ -150,93 +149,156 @@ Run ``qdbus org.kde.KWin /Effects org.kde.kwin.Effects.reconfigureEffect kwin_ge
             - **Shortcut** (string) - Run ``qdbus org.kde.kglobalaccel /component/$component org.kde.kglobalaccel.Component.shortcutNames`` for the list of shortcuts.<br>Default: **none**
           - **[KeySequence]** - Configuration for the KeySequence action.
             - **Sequence** (string) - The key sequence to run. Case-sensitive. Invalid format will cause a crash (for now). For the full list of keys see [src/gestures/actions/keysequence.h](src/gestures/actions/keysequence.h).<br>Example: ``press LEFTCTRL,press T,release LEFTCTRL,release T``.<br>Default: **none**<br>&nbsp;
-          - **[Conditions]** - Same as **[Gestures][\$Device][$Gesture][Conditions]**, but only applied to this action.
+          - **[Conditions]** - Same as **[Gestures][\$Device][$GestureId][Conditions]**, but only applied to this action.
 
 ### Example
 ```
-[Gestures][Touchpad][0]
-Type=Pinch
-Fingers=2
+[Gestures][Touchpad][0] # Swipe 3 left
+Type=Swipe
+Fingers=3
 TriggerWhenThresholdReached=true
 
-[Gestures][Touchpad][0][Conditions][0]
-WindowRegex=plasmashell
+[Gestures][Touchpad][0][Swipe]
+Direction=Left
+ThresholdX=10
 
-[Gestures][Touchpad][0][Pinch]
-Direction=Contracting
-Threshold=0.9
+[Gestures][Touchpad][0][Actions][0] # Firefox back
+Type=KeySequence
 
-[Gestures][Touchpad][0][Actions][Close Window]
-Type=GlobalShortcut
+[Gestures][Touchpad][0][Actions][0][Conditions][0]
+WindowClassRegex=firefox
 
-[Gestures][Touchpad][0][Actions][Close Window][GlobalShortcut]
-Component=ksmserver
-Shortcut=LockSession
+[Gestures][Touchpad][0][Actions][0][KeySequence]
+Sequence=press LEFTCTRL,press LEFTBRACE,release LEFTCTRL,release LEFTBRACE
 
 
-[Gestures][Touchpad][Yakuake]
+[Gestures][Touchpad][1] # Swipe 3 right
+Type=Swipe
+Fingers=3
+TriggerWhenThresholdReached=true
+
+[Gestures][Touchpad][1][Swipe]
+Direction=Right
+ThresholdX=10
+
+[Gestures][Touchpad][1][Actions][0] # Firefox forward
+Type=KeySequence
+
+[Gestures][Touchpad][1][Actions][0][Conditions][0]
+WindowClassRegex=firefox
+
+[Gestures][Touchpad][1][Actions][0][KeySequence]
+Sequence=press LEFTCTRL,press RIGHTBRACE,release LEFTCTRL,release RIGHTBRACE
+
+
+[Gestures][Touchpad][2] # Swipe 3 down
+Type=Swipe
+Fingers=3
+TriggerWhenThresholdReached=true
+
+[Gestures][Touchpad][2][Swipe]
+Direction=Down
+ThresholdY=10
+
+[Gestures][Touchpad][2][Actions][0] # Firefox refresh
+Type=KeySequence
+
+[Gestures][Touchpad][2][Actions][0][Conditions][0]
+WindowClassRegex=firefox
+
+[Gestures][Touchpad][2][Actions][0][KeySequence]
+Sequence=press LEFTCTRL,press F5,release LEFTCTRL,release F5
+
+
+[Gestures][Touchpad][3] # Swipe 4 down
 Type=Swipe
 Fingers=4
 TriggerWhenThresholdReached=true
 
-[Gestures][Touchpad][Yakuake][Swipe]
+[Gestures][Touchpad][3][Swipe]
 Direction=Down
 ThresholdY=10
 
-[Gestures][Touchpad][Yakuake][Actions][0]
+[Gestures][Touchpad][3][Actions][0] # Minimize window if not fullscreen and not maximized
 Type=GlobalShortcut
 
-[Gestures][Touchpad][Yakuake][Actions][0][GlobalShortcut]
-Component=yakuake
-Shortcut=toggle-window-state
+[Gestures][Touchpad][3][Actions][0][Conditions][0]
+Negate=true
+WindowState=Fullscreen|Maximized
+
+[Gestures][Touchpad][3][Actions][0][GlobalShortcut]
+Component=kwin
+Shortcut=Window Minimize
+
+[Gestures][Touchpad][3][Actions][1] # Unmaximize window if maximized
+Type=GlobalShortcut
+
+[Gestures][Touchpad][3][Actions][1][Conditions][0]
+WindowState=Maximized
+
+[Gestures][Touchpad][3][Actions][1][GlobalShortcut]
+Component=kwin
+Shortcut=Window Maximize
 
 
-[Gestures][Touchpad][Firefox Back]
+[Gestures][Touchpad][4] # Swipe 4 up
 Type=Swipe
-Fingers=3
+Fingers=4
 TriggerWhenThresholdReached=true
-WindowRegex=firefox
 
-[Gestures][Touchpad][Firefox Back][Swipe]
-Direction=Left
-ThresholdX=10
+[Gestures][Touchpad][4][Swipe]
+Direction=Up
+ThresholdY=10
 
-[Gestures][Touchpad][Firefox Back][Actions][0]
-Type=KeySequence
+[Gestures][Touchpad][4][Actions][0] # Maximize window if not maximized
+Type=GlobalShortcut
 
-[Gestures][Touchpad][Firefox Back][Actions][0][KeySequence]
-Sequence=press LEFTCTRL,press LEFTBRACE,release LEFTCTRL,release LEFTBRACE
+[Gestures][Touchpad][4][Actions][0][Conditions][0]
+Negate=true
+WindowState=Maximized
 
-
-[Gestures][Touchpad][Firefox Forward]
-Type=Swipe
-Fingers=3
-TriggerWhenThresholdReached=true
-WindowRegex=firefox
-
-[Gestures][Touchpad][Firefox Forward][Swipe]
-Direction=Right
-ThresholdX=10
-
-[Gestures][Touchpad][Firefox Forward][Actions][0]
-Type=KeySequence
-
-[Gestures][Touchpad][Firefox Forward][Actions][0][KeySequence]
-Sequence=press LEFTCTRL,press RIGHTBRACE,release LEFTCTRL,release RIGHTBRACE
+[Gestures][Touchpad][4][Actions][0][GlobalShortcut]
+Component=kwin
+Shortcut=Window Maximize
 
 
-[Gestures][Touchpad][Krunner]
-Type=Hold
+[Gestures][Touchpad][5] # Pinch 2 in
+Type=Pinch
 Fingers=2
 TriggerWhenThresholdReached=true
+TriggerOneActionOnly=true
 
-[Gestures][Touchpad][Krunner][Hold]
-Threshold=100
+[Gestures][Touchpad][5][Pinch]
+Direction=Contracting
+Threshold=0.9
 
-[Gestures][Touchpad][Krunner][Actions][0]
+[Gestures][Touchpad][5][Actions][0] # Lock session if no active window
 Type=GlobalShortcut
 
-[Gestures][Touchpad][Krunner][Actions][0][GlobalShortcut]
+[Gestures][Touchpad][5][Actions][0][Conditions][0]
+WindowClassRegex=plasmashell
+
+[Gestures][Touchpad][5][Actions][0][GlobalShortcut]
+Component=ksmserver
+Shortcut=Lock Session
+
+[Gestures][Touchpad][5][Actions][1] # Close window, because of TriggerOneActionOnly=true, this will only trigger when the previous condition isn't satisfied
+Type=GlobalShortcut
+
+[Gestures][Touchpad][5][Actions][1][GlobalShortcut]
+Component=kwin
+Shortcut=Window Close
+
+
+[Gestures][Touchpad][6] # Hold 3
+Type=Hold
+Fingers=3
+TriggerWhenThresholdReached=true
+
+[Gestures][Touchpad][6][Actions][0] # Launch krunner
+Type=GlobalShortcut
+
+[Gestures][Touchpad][6][Actions][0][GlobalShortcut]
 Component=org_kde_krunner_desktop
 Shortcut=_launch
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # KWin Gestures
-Custom touchpad gestures for Plasma 6.
+Custom touchpad gestures for KDE Plasma 6.
 
 Tested on 6.1.5 and 6.2. X11 is not supported.
+
+# Features
+- Override built-in gestures
+- Application-specific gestures
 
 # Installation
 <details>
@@ -110,72 +114,64 @@ Run ``qdbus org.kde.KWin /Effects org.kde.kwin.Effects.reconfigureEffect kwin_ge
 ### Configuration file structure
 
 - **[Gestures]**
-  - **[$device]** (enum) - Which device to add this gesture for (``Touchpad``).<br>
-    - **[$name]** (string) - Unique name for the gesture.
+  - **[$Device]** (enum) - Which device to add this gesture for (``Touchpad``).<br>
+    - **[$Gesture]** (string) - Unique name for the gesture.
       - **Type** (enum) - ``Hold``, ``Pinch``, ``Swipe``
-      - **Fingers** (int) - Number of fingers required to trigger this gesture.<br>Sets ``MinimumFingers`` and ``MaximumFingers``.<br>Minimum value is 2 for hold and pinch gestures, 3 for swipe.<br>Maximum value is 4. 
-      - **MinimumFingers** (int) - Minimum number of fingers required to trigger this gesture.<br>See **Fingers** for accepted values.
-      - **MaximumFingers** (int) - Maximum number of fingers required to trigger this gesture.<br>See **Fingers** for accepted values.
-      - **TriggerWhenThresholdReached** (bool) - Whether to trigger the gesture immediately after the specified threshold is reached.<br>Default: false
-      - **WindowRegex** (string) - A regular expression executed on the currently focused window's resource class and resource name. If a match is not found for either, the gesture will be skipped. This allows you to create gestures only for specific applications.<br>Default: none<br>&nbsp;
+      - **Fingers** (int) - Number of fingers required to trigger this gesture.<br>Sets **MinimumFingers** and **MaximumFingers**.<br>Minimum value: **2** for hold and pinch gestures, **3** for swipe.<br>Default: **none** 
+      - **MinimumFingers** (int) - Minimum number of fingers required to trigger this gesture.<br>See **Fingers** for accepted values.<br>Default: **none**
+      - **MaximumFingers** (int) - Maximum number of fingers required to trigger this gesture.<br>See **Fingers** for accepted values.<br>Default: **none**
+      - **TriggerWhenThresholdReached** (bool) - Whether to trigger the gesture immediately after the specified threshold is reached.<br>Default: **false**
+      - **TriggerOneActionOnly** (bool) - Whether to trigger only the first action that satisfies a condition.<br>Default: **false**
+      - **BlockBuiltInGesture** (bool) - Whether to block the built-in gesture if this one isn't triggered due to unsatisfied conditions.<br>Default: **true**<br>&nbsp;
       - **[Hold]** - Configuration for hold gestures.
-        - **Threshold** (int) - In milliseconds.<br>Default: 0
+        - **Threshold** (int) - In milliseconds.<br>Default: **0**
       - **[Pinch]** - Configuration for pinch gestures.
         - **Direction** (enum) - ``Contracting``, ``Expanding``
-        - **Threshold** (float) - Should be >= 1.0 for expanding gestures and =< 1.0 for contracting gestures.<br>Default: 1.0
+        - **Threshold** (float) - Should be >= 1.0 for expanding gestures and =< 1.0 for contracting gestures.<br>Default: **1.0**
       - **[Swipe]** - Configuration for swipe gestures.
         - **Direction** (enum) - ``Left``, ``Right``, ``Up``, ``Down``
-        - **ThresholdX** (int) - Threshold for the X axis in pixels.<br>Only used if **Direction** is ``Left`` or ``Right``.<br>Default: 0
-        - **ThresholdY** (int) - Threshold for the Y axis in pixels.<br>Only used if **Direction** is ``Up`` or ``Down``.<br>Default: 0<br>&nbsp;
+        - **ThresholdX** (int) - Threshold for the X axis in pixels.<br>Only used if **Direction** is ``Left`` or ``Right``.<br>Default: **0**
+        - **ThresholdY** (int) - Threshold for the Y axis in pixels.<br>Only used if **Direction** is ``Up`` or ``Down``.<br>Default: **0**<br>&nbsp;
+      - **[Conditions]**
+        - **[$Condition]** (string) - Unique name for this condition.
+          - **Negate** (bool) - If true, this condition will be satisfied only when none of the specified properties are.<br>Default: **false**
+          - **WindowClassRegex** (string) - A regular expression executed on the currently focused window's resource class and resource name. If a match is not found for either, the condition will not be satisfied.<br>Default: **none**
+          - **WindowState** (enum) - ``Fullscreen``, ``Maximized``. Values can be combined using the | separator, For example, ``Fullscreen|Maximized`` will match either fullscreen or maximized windows.<br>Default: **none**<br>&nbsp;
       - **[Actions]** - What do to when the gesture is triggered. Actions are executed in order as they appear in the configuration file.
-        - **[$name]** (string) - Unique name for the action.
+        - **[$Action]** (string) - Unique name for the action.
           - **Type** (enum)
             - ``Command`` - Run a command.
             - ``GlobalShortcut`` - Invoke a global shortcut.
             - ``KeySequence`` - Send keystrokes.<br>&nbsp;
           - **[Command]** - Configuration for the GlobalShortcut action.
-            - **Command** (string) - The command to run.
+            - **Command** (string) - The command to run.<br>Default: **none**
           - **[GlobalShortcut]** - Configuration for the GlobalShortcut action.
-            - **Component** (string) - Run ``qdbus org.kde.kglobalaccel`` for a list of available components. Components start with the ``/component/`` prefix. Don't add the prefix here.
-            - **Shortcut** (string) - See the ``~/.config/kglobalshortcutsrc`` file for a list of available shortcuts. The group name (or similar) is the component and the key (everything before *=*) is the shortcut.
+            - **Component** (string) - Run ``qdbus org.kde.kglobalaccel | grep /component`` for the list of components. Don't put the ``/component/`` prefix here.<br>Default: **none**
+            - **Shortcut** (string) - Run ``qdbus org.kde.kglobalaccel /component/$component org.kde.kglobalaccel.Component.shortcutNames`` for the list of shortcuts.<br>Default: **none**
           - **[KeySequence]** - Configuration for the KeySequence action.
-            - **Sequence** (string) - The key sequence to run. Case-sensitive. Invalid format will cause a crash (for now).<br>Example: ``press LEFTCTRL,press T,release LEFTCTRL,release T``. For the full list of keys see [src/gestures/actions/keysequence.h](src/gestures/actions/keysequence.h).
+            - **Sequence** (string) - The key sequence to run. Case-sensitive. Invalid format will cause a crash (for now). For the full list of keys see [src/gestures/actions/keysequence.h](src/gestures/actions/keysequence.h).<br>Example: ``press LEFTCTRL,press T,release LEFTCTRL,release T``.<br>Default: **none**<br>&nbsp;
+          - **[Conditions]** - Same as **[Gestures][\$Device][$Gesture][Conditions]**, but only applied to this action.
 
 ### Example
 ```
-[Gestures][Touchpad][Lock Screen]
+[Gestures][Touchpad][0]
 Type=Pinch
 Fingers=2
 TriggerWhenThresholdReached=true
+
+[Gestures][Touchpad][0][Conditions][0]
 WindowRegex=plasmashell
 
-[Gestures][Touchpad][Lock Screen][Pinch]
+[Gestures][Touchpad][0][Pinch]
 Direction=Contracting
 Threshold=0.9
 
-[Gestures][Touchpad][Lock Screen][Actions][0]
+[Gestures][Touchpad][0][Actions][Close Window]
 Type=GlobalShortcut
 
-[Gestures][Touchpad][Lock Screen][Actions][0][GlobalShortcut]
+[Gestures][Touchpad][0][Actions][Close Window][GlobalShortcut]
 Component=ksmserver
-Shortcut=Lock Session
-
-
-[Gestures][Touchpad][Close Window]
-Type=Pinch
-Fingers=2
-TriggerWhenThresholdReached=true
-
-[Gestures][Touchpad][Close Window][Pinch]
-Direction=Contracting
-Threshold=0.9
-
-[Gestures][Touchpad][Close Window][Actions][0]
-Type=GlobalShortcut
-
-[Gestures][Touchpad][Close Window][Actions][0][GlobalShortcut]
-Component=kwin
-Shortcut=Window Close
+Shortcut=LockSession
 
 
 [Gestures][Touchpad][Yakuake]
@@ -245,5 +241,10 @@ Component=org_kde_krunner_desktop
 Shortcut=_launch
 ```
 
+# Gesture recognition issues
+Before reporting any issues related to gesture recognition, run ``libinput debug-events`` as root and ensure the gesture is recognized properly. If it's not, there's nothing I can do.
+
+Depending on the touchpad, 3 or 4-finger pinch gestures may sometimes be incorrectly interpreted as swipe gestures due to the touchpad only being able to track 2 fingers. As a workaround, move only 2 fingers in opposite directions. See https://wayland.freedesktop.org/libinput/doc/1.25.0/gestures.html#gestures-on-two-finger-touchpads for more information.
+
 # Credits
-- [KWin](https://invent.kde.org/plasma/kwin)
+- [KWin](https://invent.kde.org/plasma/kwin) - Gesture recognition, sending keystrokes

--- a/package.nix
+++ b/package.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation rec {
   pname = "kwin-gestures";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = ./.;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,11 +5,13 @@ set(kwin_gestures_SOURCES
     virtualkeyboard.cpp
     config/config.cpp
     gesturerecognizer.cpp
+    gestures/condition.cpp
     gestures/gesture.cpp
     gestures/holdgesture.cpp
     gestures/pinchgesture.cpp
     gestures/swipegesture.cpp
-        gestures/actions/command.cpp
+    gestures/actions/action.cpp
+    gestures/actions/command.cpp
     gestures/actions/globalshortcut.cpp
     gestures/actions/keysequence.cpp
 )

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "gestures/gesture.h"
+#include <KConfigGroup>
 
 class Config
 {
@@ -19,4 +20,6 @@ public:
 
 private:
     Config() = default;
+
+    std::vector<Condition> readConditions(const KConfigGroup &group) const;
 };

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -21,5 +21,6 @@ public:
 private:
     Config() = default;
 
-    std::vector<Condition> readConditions(const KConfigGroup &group) const;
+    static std::vector<Condition> readConditions(const KConfigGroup &group);
+    static std::vector<int> stringIntListToSortedIntVector(const QList<QString> &list);
 };

--- a/src/gesturerecognizer.cpp
+++ b/src/gesturerecognizer.cpp
@@ -20,7 +20,7 @@ bool GestureRecognizer::holdGestureBegin(int fingerCount, std::chrono::microseco
     for (std::shared_ptr<Gesture> &gesture : Config::instance().gestures)
     {
         std::shared_ptr<HoldGesture> holdGesture = std::dynamic_pointer_cast<HoldGesture>(gesture);
-        if (!holdGesture || !gesture->meetsConditions(fingerCount))
+        if (!holdGesture || !gesture->satisfiesConditions(fingerCount))
             continue;
 
         m_activeHoldGestures << holdGesture;
@@ -73,7 +73,7 @@ bool GestureRecognizer::swipeGestureBegin(uint fingerCount)
     for (std::shared_ptr<Gesture> &gesture : Config::instance().gestures)
     {
         const std::shared_ptr<SwipeGesture> swipeGesture = std::dynamic_pointer_cast<SwipeGesture>(gesture);
-        if (!swipeGesture || !gesture->meetsConditions(fingerCount))
+        if (!swipeGesture || !gesture->satisfiesConditions(fingerCount))
             continue;
 
         switch (swipeGesture->direction())
@@ -168,7 +168,7 @@ bool GestureRecognizer::swipeGestureUpdate(const QPointF &delta)
                 gesture->triggered();
                 m_activeSwipeGestures.erase(it);
                 m_hasActiveTriggeredSwipeGesture = true;
-                swipeGestureEnd(false);
+                swipeGestureEnd(true, false);
                 return true;
             }
 
@@ -194,13 +194,13 @@ bool GestureRecognizer::swipeGestureCancelled()
     return hadActiveGestures;
 }
 
-bool GestureRecognizer::swipeGestureEnd(bool resetHasActiveTriggeredGesture)
+bool GestureRecognizer::swipeGestureEnd(bool dontTriggerGestures, bool resetHasActiveTriggeredGesture)
 {
     bool hadActiveGestures = !m_activeSwipeGestures.isEmpty();
     const QPointF delta = m_currentDelta;
     for (const auto &gesture : std::as_const(m_activeSwipeGestures))
     {
-        if (gesture->thresholdReached(delta))
+        if (!dontTriggerGestures && gesture->thresholdReached(delta))
             gesture->triggered();
         else
             gesture->cancelled();
@@ -224,7 +224,7 @@ bool GestureRecognizer::pinchGestureBegin(uint fingerCount)
     for (const std::shared_ptr<Gesture> &gesture : Config::instance().gestures)
     {
         const std::shared_ptr<PinchGesture> pinchGesture = std::dynamic_pointer_cast<PinchGesture>(gesture);
-        if (!pinchGesture || !gesture->meetsConditions(fingerCount))
+        if (!pinchGesture || !gesture->satisfiesConditions(fingerCount))
             continue;
 
         // direction doesn't matter yet

--- a/src/gesturerecognizer.h
+++ b/src/gesturerecognizer.h
@@ -24,7 +24,7 @@ public:
 
     bool swipeGestureBegin(uint fingerCount);
     bool swipeGestureUpdate(const QPointF &delta);
-    bool swipeGestureEnd(bool resetHasActiveTriggeredGesture = true);
+    bool swipeGestureEnd(bool dontTriggerGestures = false, bool resetHasActiveTriggeredGesture = true);
     bool swipeGestureCancelled();
 
     bool pinchGestureBegin(uint fingerCount);

--- a/src/gestures/actions/action.cpp
+++ b/src/gestures/actions/action.cpp
@@ -1,0 +1,14 @@
+#include "action.h"
+
+void GestureAction::addCondition(const Condition &condition)
+{
+    m_conditions.push_back(condition);
+}
+
+bool GestureAction::satisfiesConditions() const
+{
+    return m_conditions.empty() || std::find_if(m_conditions.begin(), m_conditions.end(), [](const Condition &condition)
+    {
+        return condition.isSatisfied();
+    }) != m_conditions.end();
+}

--- a/src/gestures/actions/action.h
+++ b/src/gestures/actions/action.h
@@ -1,12 +1,18 @@
 #pragma once
 
+#include "gestures/condition.h"
+
 class GestureAction
 {
 public:
     virtual ~GestureAction() = default;
 
-    virtual void execute() { };
+    virtual void execute() const { };
 
+    void addCondition(const Condition &condition);
+    bool satisfiesConditions() const;
 protected:
     GestureAction() = default;
+private:
+    std::vector<Condition> m_conditions;
 };

--- a/src/gestures/actions/command.cpp
+++ b/src/gestures/actions/command.cpp
@@ -7,7 +7,7 @@ CommandGestureAction::CommandGestureAction(QString command)
 {
 }
 
-void CommandGestureAction::execute()
+void CommandGestureAction::execute() const
 {
     std::ignore = std::system((m_command + " &").toStdString().c_str());
 }

--- a/src/gestures/actions/command.h
+++ b/src/gestures/actions/command.h
@@ -6,9 +6,9 @@
 class CommandGestureAction : public GestureAction
 {
 public:
-    CommandGestureAction(QString command);
+    explicit CommandGestureAction(QString command);
 
-    void execute() override;
+    void execute() const override;
 private:
     const QString m_command;
 };

--- a/src/gestures/actions/globalshortcut.cpp
+++ b/src/gestures/actions/globalshortcut.cpp
@@ -6,7 +6,7 @@ GlobalShortcutGestureAction::GlobalShortcutGestureAction(QString component, QStr
 {
 }
 
-void GlobalShortcutGestureAction::execute()
+void GlobalShortcutGestureAction::execute() const
 {
     QDBusInterface interface("org.kde.kglobalaccel", "/component/" + m_component, "org.kde.kglobalaccel.Component");
     interface.call("invokeShortcut", m_shortcut);

--- a/src/gestures/actions/globalshortcut.h
+++ b/src/gestures/actions/globalshortcut.h
@@ -8,7 +8,7 @@ class GlobalShortcutGestureAction : public GestureAction
 public:
     GlobalShortcutGestureAction(QString component, QString shortcut);
 
-    void execute() override;
+    void execute() const override;
 private:
     const QString m_component;
     const QString m_shortcut;

--- a/src/gestures/actions/keysequence.cpp
+++ b/src/gestures/actions/keysequence.cpp
@@ -1,12 +1,13 @@
 #include "keysequence.h"
 #include "virtualkeyboard.h"
+#include "xkb.h"
 
 KeySequenceGestureAction::KeySequenceGestureAction(QString sequence)
     : m_sequence(std::move(sequence))
 {
 }
 
-void KeySequenceGestureAction::execute()
+void KeySequenceGestureAction::execute() const
 {
     VirtualKeyboard virtualKeyboard;
     for (const auto &command : m_sequence.split(","))

--- a/src/gestures/actions/keysequence.h
+++ b/src/gestures/actions/keysequence.h
@@ -519,7 +519,7 @@ class KeySequenceGestureAction : public GestureAction
 public:
     explicit KeySequenceGestureAction(QString sequence);
 
-    void execute() override;
+    void execute() const override;
 private:
     const QString m_sequence;
 };

--- a/src/gestures/condition.cpp
+++ b/src/gestures/condition.cpp
@@ -1,0 +1,34 @@
+#include "condition.h"
+#include "effect/effecthandler.h"
+#include "window.h"
+
+Condition::Condition(bool negate, std::optional<QRegularExpression> windowClassRegex, std::optional<WindowState> windowState)
+    : m_negate(negate),
+      m_windowClassRegex(std::move(windowClassRegex)),
+      m_windowState(windowState)
+{
+}
+
+bool Condition::isSatisfied() const
+{
+    const auto window = KWin::effects->activeWindow();
+    if (!window)
+        return false;
+
+    if ((m_windowClassRegex && !m_windowClassRegex.value().pattern().isEmpty())
+        && !(m_windowClassRegex.value().match(window->window()->resourceClass()).hasMatch()
+            || m_windowClassRegex.value().match(window->window()->resourceName()).hasMatch()))
+        return m_negate;
+
+    if (m_windowState) {
+        bool satisfiesFullscreen = (m_windowState.value() & WindowState::Fullscreen) && window->isFullScreen();
+        bool satisfiesMaximized = (m_windowState.value() & WindowState::Maximized)
+            && window->frameGeometry() == KWin::effects->clientArea(KWin::MaximizeArea, KWin::effects->activeScreen(), KWin::effects->currentDesktop());
+
+        return m_negate
+            ? (!satisfiesFullscreen && !satisfiesMaximized)
+            : (satisfiesFullscreen || satisfiesMaximized);
+    }
+
+    return !m_negate;
+}

--- a/src/gestures/condition.h
+++ b/src/gestures/condition.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QRegularExpression>
+
+enum WindowState
+{
+    Unimportant = 0,
+    Fullscreen = 1,
+    Maximized = 2,
+};
+inline WindowState operator|(WindowState a, WindowState b)
+{
+    return static_cast<WindowState>(static_cast<int>(a) | static_cast<int>(b));
+}
+
+class Condition
+{
+public:
+    Condition(bool negate, std::optional<QRegularExpression> windowClassRegex, std::optional<WindowState> windowState);
+
+    bool isSatisfied() const;
+private:
+    const bool m_negate;
+    const std::optional<QRegularExpression> m_windowClassRegex;
+    const std::optional<WindowState> m_windowState;
+};

--- a/src/gestures/gesture.cpp
+++ b/src/gestures/gesture.cpp
@@ -2,11 +2,12 @@
 #include "gesture.h"
 #include "window.h"
 
-Gesture::Gesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers)
+Gesture::Gesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, bool triggerOneActionOnly)
     : m_device(device),
       m_triggerWhenThresholdReached(triggerWhenThresholdReached),
       m_minimumFingers(minimumFingers),
-      m_maximumFingers(maximumFingers)
+      m_maximumFingers(maximumFingers),
+      m_triggerOneActionOnly(triggerOneActionOnly)
 {
 }
 
@@ -18,6 +19,8 @@ void Gesture::triggered()
             continue;
 
         action->execute();
+        if (m_triggerOneActionOnly)
+            break;
     }
 }
 

--- a/src/gestures/gesture.h
+++ b/src/gestures/gesture.h
@@ -27,13 +27,14 @@ public:
     void addTriggerAction(const std::shared_ptr<const GestureAction> &action);
     void addCondition(const Condition &condition);
 protected:
-    Gesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers);
+    Gesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, bool triggerOneActionOnly);
 
     const bool m_triggerWhenThresholdReached;
 private:
     const InputDeviceType m_device;
     const uint m_minimumFingers;
     const uint m_maximumFingers;
+    const bool m_triggerOneActionOnly;
 
     std::vector<Condition> m_conditions;
 

--- a/src/gestures/gesture.h
+++ b/src/gestures/gesture.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "actions/action.h"
+#include "condition.h"
 #include <QRegularExpression>
 #include <vector>
 
@@ -17,24 +18,24 @@ public:
 
     bool triggerWhenThresholdReached() const { return m_triggerWhenThresholdReached; };
 
-    virtual void cancelled();
-    virtual void started();
+    virtual void cancelled() { };
+    virtual void started() { };
     virtual void triggered();
 
-    bool meetsConditions(uint fingerCount) const;
+    bool satisfiesConditions(uint fingerCount) const;
 
-    void addTriggerAction(std::unique_ptr<GestureAction> action);
+    void addTriggerAction(const std::shared_ptr<const GestureAction> &action);
+    void addCondition(const Condition &condition);
 protected:
-    Gesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, QRegularExpression windowRegex);
+    Gesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers);
 
     const bool m_triggerWhenThresholdReached;
 private:
     const InputDeviceType m_device;
     const uint m_minimumFingers;
     const uint m_maximumFingers;
-    const QRegularExpression m_windowRegex;
 
-    std::vector<std::unique_ptr<GestureAction>> m_cancelledActions;
-    std::vector<std::unique_ptr<GestureAction>> m_startedActions;
-    std::vector<std::unique_ptr<GestureAction>> m_triggerActions;
+    std::vector<Condition> m_conditions;
+
+    std::vector<std::shared_ptr<const GestureAction>> m_triggerActions;
 };

--- a/src/gestures/holdgesture.cpp
+++ b/src/gestures/holdgesture.cpp
@@ -1,7 +1,7 @@
 #include "holdgesture.h"
 
-HoldGesture::HoldGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, QRegularExpression windowRegex, uint threshold)
-    : Gesture(device, triggerWhenThresholdReached, minimumFingers, maximumFingers, std::move(windowRegex)),
+HoldGesture::HoldGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, uint threshold)
+    : Gesture(device, triggerWhenThresholdReached, minimumFingers, maximumFingers),
       m_threshold(threshold)
 {
     connect(&m_timer, &QTimer::timeout, this, [this]() {

--- a/src/gestures/holdgesture.cpp
+++ b/src/gestures/holdgesture.cpp
@@ -1,7 +1,7 @@
 #include "holdgesture.h"
 
-HoldGesture::HoldGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, uint threshold)
-    : Gesture(device, triggerWhenThresholdReached, minimumFingers, maximumFingers),
+HoldGesture::HoldGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, uint threshold, bool triggerOneActionOnly)
+    : Gesture(device, triggerWhenThresholdReached, minimumFingers, maximumFingers, triggerOneActionOnly),
       m_threshold(threshold)
 {
     connect(&m_timer, &QTimer::timeout, this, [this]() {

--- a/src/gestures/holdgesture.h
+++ b/src/gestures/holdgesture.h
@@ -7,7 +7,7 @@ class HoldGesture : public Gesture
 {
     Q_OBJECT
 public:
-    HoldGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, uint threshold);
+    HoldGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, uint threshold, bool triggerOneActionOnly);
 
     void cancelled() override;
     void started() override;

--- a/src/gestures/holdgesture.h
+++ b/src/gestures/holdgesture.h
@@ -7,7 +7,7 @@ class HoldGesture : public Gesture
 {
     Q_OBJECT
 public:
-    HoldGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, QRegularExpression windowRegex, uint threshold);
+    HoldGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, uint threshold);
 
     void cancelled() override;
     void started() override;

--- a/src/gestures/pinchgesture.cpp
+++ b/src/gestures/pinchgesture.cpp
@@ -1,7 +1,7 @@
 #include "pinchgesture.h"
 
-PinchGesture::PinchGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, KWin::PinchDirection direction, qreal threshold)
-    : Gesture(device, triggerWhenThresholdReached, minimumFingers, maximumFingers),
+PinchGesture::PinchGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, bool triggerOneActionOnly, KWin::PinchDirection direction, qreal threshold)
+    : Gesture(device, triggerWhenThresholdReached, minimumFingers, maximumFingers, triggerOneActionOnly),
       m_direction(direction), m_threshold(threshold)
 {
 }

--- a/src/gestures/pinchgesture.cpp
+++ b/src/gestures/pinchgesture.cpp
@@ -1,7 +1,7 @@
 #include "pinchgesture.h"
 
-PinchGesture::PinchGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, QRegularExpression windowRegex, KWin::PinchDirection direction, qreal threshold)
-    : Gesture(device, triggerWhenThresholdReached, minimumFingers, maximumFingers, windowRegex),
+PinchGesture::PinchGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, KWin::PinchDirection direction, qreal threshold)
+    : Gesture(device, triggerWhenThresholdReached, minimumFingers, maximumFingers),
       m_direction(direction), m_threshold(threshold)
 {
 }

--- a/src/gestures/pinchgesture.h
+++ b/src/gestures/pinchgesture.h
@@ -7,7 +7,7 @@
 class PinchGesture : public Gesture
 {
 public:
-    PinchGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, KWin::PinchDirection direction, qreal threshold);
+    PinchGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, bool triggerOneActionOnly, KWin::PinchDirection direction, qreal threshold);
 
     KWin::PinchDirection direction() const { return m_direction; }
 

--- a/src/gestures/pinchgesture.h
+++ b/src/gestures/pinchgesture.h
@@ -7,7 +7,7 @@
 class PinchGesture : public Gesture
 {
 public:
-    PinchGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, QRegularExpression windowRegex, KWin::PinchDirection direction, qreal threshold);
+    PinchGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, KWin::PinchDirection direction, qreal threshold);
 
     KWin::PinchDirection direction() const { return m_direction; }
 

--- a/src/gestures/swipegesture.cpp
+++ b/src/gestures/swipegesture.cpp
@@ -1,7 +1,7 @@
 #include "swipegesture.h"
 
-SwipeGesture::SwipeGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, QRegularExpression windowRegex, KWin::SwipeDirection direction, QPointF threshold)
-    : Gesture(device, triggerWhenThresholdReached, minimumFingers, maximumFingers, std::move(windowRegex)),
+SwipeGesture::SwipeGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, KWin::SwipeDirection direction, QPointF threshold)
+    : Gesture(device, triggerWhenThresholdReached, minimumFingers, maximumFingers),
       m_direction(direction),
       m_threshold(threshold)
 {

--- a/src/gestures/swipegesture.cpp
+++ b/src/gestures/swipegesture.cpp
@@ -1,7 +1,7 @@
 #include "swipegesture.h"
 
-SwipeGesture::SwipeGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, KWin::SwipeDirection direction, QPointF threshold)
-    : Gesture(device, triggerWhenThresholdReached, minimumFingers, maximumFingers),
+SwipeGesture::SwipeGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, bool triggerOneActionOnly, KWin::SwipeDirection direction, QPointF threshold)
+    : Gesture(device, triggerWhenThresholdReached, minimumFingers, maximumFingers, triggerOneActionOnly),
       m_direction(direction),
       m_threshold(threshold)
 {

--- a/src/gestures/swipegesture.h
+++ b/src/gestures/swipegesture.h
@@ -6,7 +6,7 @@
 class SwipeGesture : public Gesture
 {
 public:
-    SwipeGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, QRegularExpression windowRegex, KWin::SwipeDirection direction, QPointF threshold);
+    SwipeGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, KWin::SwipeDirection direction, QPointF threshold);
 
     KWin::SwipeDirection direction() const { return m_direction; }
 

--- a/src/gestures/swipegesture.h
+++ b/src/gestures/swipegesture.h
@@ -6,7 +6,7 @@
 class SwipeGesture : public Gesture
 {
 public:
-    SwipeGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, KWin::SwipeDirection direction, QPointF threshold);
+    SwipeGesture(InputDeviceType device, bool triggerWhenThresholdReached, uint minimumFingers, uint maximumFingers, bool triggerOneActionOnly, KWin::SwipeDirection direction, QPointF threshold);
 
     KWin::SwipeDirection direction() const { return m_direction; }
 


### PR DESCRIPTION
Closes #3.


# Configuration file structure changes
### New entries
- **[Gestures][$Device][$Gesture]**
  - **TriggerOneActionOnly** (bool) - Whether to trigger only the first action that satisfies a condition.<br>Default: **false**<br>&nbsp; 
  - **[Conditions]** - At least one condition (or 0 if none specified) must be satisfied in order for this gesture to be triggered.
      - **[$ConditionId]** (int) - Unique ID for this condition.
        - **Negate** (bool) - If true, this condition will be satisfied only when none of its specified properties are.<br>Default: **false**
        - **WindowClassRegex** (string) - A regular expression executed on the currently focused window's resource class and resource name. If a match is not found for either, the condition will not be satisfied.<br>Default: **none**
        - **WindowState** (enum) - ``Fullscreen``, ``Maximized``. Values can be combined using the | separator, For example, ``Fullscreen|Maximized`` will match either fullscreen or maximized windows.<br>Default: **none**<br>&nbsp;
  - **[Actions]**
    - **[$Action]**
      - **[Conditions]** - Same as **[Gestures][\$Device][$Gesture][Conditions]**, but only applied to this action.  
### Changed entries
- **[Gestures][$Device][$Gesture] WindowRegex** - Renamed and moved to **[Gestures][$Device][$Gesture][Conditions][$Condition] WindowClassRegex** and **[Gestures][$Device][$Gesture][Actions][$Action][Conditions][$Condition] WindowClassRegex**.
- **[Gestures][$Device][$Gesture]**, **[Gestures][$Device][$Gesture][Actions][$Action]** - Types of **$Gesture** and **$Action** were changed from string to int due to KConfig returning groups in a random order. You can instead use comments (starting with #) anywhere to make your configuration more readable.