### PR TITLE
config: use arrays instead of space-separated values

### DIFF
--- a/docs/example_gestures.md
+++ b/docs/example_gestures.md
@@ -17,14 +17,14 @@ Not guaranteed to work on all keyboard layouts. It may be necessary to change th
   actions:
     # Firefox
     - on: begin
-      keyboard: leftctrl+leftbrace
+      keyboard: [ leftctrl+leftbrace ]
 
       conditions:
         - window_class: firefox
 
     # Dolphin
     - on: begin
-      keyboard: backspace
+      keyboard: [ backspace ]
 
       conditions:
         - window_class: dolphin
@@ -37,14 +37,14 @@ Not guaranteed to work on all keyboard layouts. It may be necessary to change th
   actions:
     # Firefox
     - on: begin
-      keyboard: leftctrl+rightbrace
+      keyboard: [ leftctrl+rightbrace ]
 
       conditions:
         - window_class: firefox
 
     # Dolphin
     - on: begin
-      keyboard: leftalt+right
+      keyboard: [ leftalt+right ]
 
       conditions:
         - window_class: dolphin
@@ -94,15 +94,15 @@ Stop all audio before trying this, as the threshold may be too small for some de
       block_other: true # Prevent the minimize window action from triggering during the same gesture
 
       conditions:
-        - window_state: maximized
+        - window_state: [ maximized ]
 
     # Minimize window if not fullscreen and not maximized
     - on: begin
       plasma_shortcut: kwin,Window Minimize
 
       conditions:
-        - negate: window_state
-          window_state: fullscreen maximized
+        - negate: [ window_state ]
+          window_state: [ fullscreen, maximized ]
 
 # Maximize
 - type: swipe
@@ -115,8 +115,8 @@ Stop all audio before trying this, as the threshold may be too small for some de
       plasma_shortcut: kwin,Window Maximize
 
       conditions:
-        - negate: window_state
-          window_state: maximized
+        - negate: [ window_state ]
+          window_state: [ maximized ]
 
 # Close window
 - type: pinch
@@ -161,18 +161,18 @@ Stop all audio before trying this, as the threshold may be too small for some de
 
   actions:
     - on: begin
-      keyboard: +leftalt tab
+      keyboard: [ +leftalt, tab ]
 
     - on: update
       interval: -75
-      keyboard: leftshift+tab
+      keyboard: [ leftshift+tab ]
 
     - on: update
       interval: 75
-      keyboard: tab
+      keyboard: [ tab ]
 
     - on: end_cancel
-      keyboard: -leftalt
+      keyboard: [ -leftalt ]
 
 # Quick window switching (left)
 - type: swipe
@@ -182,7 +182,7 @@ Stop all audio before trying this, as the threshold may be too small for some de
 
   actions:
     - on: begin
-      keyboard: leftalt+leftshift+tab
+      keyboard: [ leftalt+leftshift+tab ]
 
 # Quick window switching (right)
 - type: swipe
@@ -192,7 +192,7 @@ Stop all audio before trying this, as the threshold may be too small for some de
 
   actions:
     - on: begin
-      keyboard: leftalt+tab
+      keyboard: [ leftalt+tab ]
 ```
 
 ## KRunner

--- a/src/libgestures/libgestures/yaml_convert.h
+++ b/src/libgestures/libgestures/yaml_convert.h
@@ -52,7 +52,7 @@ struct convert<std::shared_ptr<libgestures::Condition>>
 
         const auto negatedNode = node["negate"];
         if (negatedNode.IsDefined()) {
-            for (const auto &negatedRaw : negatedNode.as<QString>("").split(" ")) {
+            for (const auto &negatedRaw : negatedNode.as<QStringList>(QStringList())) {
                 if (negatedRaw.contains("window_class")) {
                     condition->setNegateWindowClass(true);
                 } else if (negatedRaw.contains("window_state")) {
@@ -143,7 +143,7 @@ struct convert<std::shared_ptr<libgestures::GestureAction>>
             action.reset(commandAction);
         } else if (node["keyboard"].IsDefined()) {
             auto keySequenceAction = new libgestures::KeySequenceGestureAction;
-            keySequenceAction->setSequence(node["keyboard"].as<QString>());
+            keySequenceAction->setSequence(node["keyboard"].as<QStringList>().join(" "));
             action.reset(keySequenceAction);
         } else if (node["plasma_shortcut"].IsDefined()) {
             auto plasmaShortcutAction = new libgestures::KDEGlobalShortcutGestureAction;
@@ -284,7 +284,7 @@ struct convert<libgestures::WindowStates>
     static bool decode(const Node &node, libgestures::WindowStates &windowStates)
     {
         windowStates = static_cast<libgestures::WindowState>(0);
-        for (const auto &stateRaw : node.as<QString>().split(" ")) {
+        for (const auto &stateRaw : node.as<QStringList>()) {
             if (stateRaw == "maximized") {
                 windowStates |= libgestures::WindowState::Maximized;
             } else if (stateRaw == "fullscreen") {
@@ -328,6 +328,18 @@ struct convert<QString>
     static bool decode(const Node &node, QString &s)
     {
         s = QString::fromStdString(node.as<std::string>());
+        return true;
+    }
+};
+
+template <>
+struct convert<QStringList>
+{
+    static bool decode(const Node &node, QStringList &list)
+    {
+        for (const auto &s : node.as<std::vector<QString>>()) {
+            list << s;
+        }
         return true;
     }
 };


### PR DESCRIPTION
Configuration documentation will be updated in #39.

# Breaking changes:
- Types of *Action.keyboard*, *Condition.negated* and *Condition.window_state* are now lists