### PR TITLE
kwin: fix config file watcher

### DIFF
--- a/src/kwin/effect.cpp
+++ b/src/kwin/effect.cpp
@@ -24,6 +24,7 @@ Effect::Effect()
 
     if (!QFile::exists(configFile)) {
         QFile(configFile).open(QIODevice::WriteOnly);
+        configureWatcher();
     }
 
     connect(&m_configFileWatcher, &QFileSystemWatcher::directoryChanged, this, &Effect::slotConfigDirectoryChanged);
@@ -71,9 +72,14 @@ void Effect::reconfigure(ReconfigureFlags flags)
     }
 
     if (m_autoReload) {
-        m_configFileWatcher.addPath(configFile);
-        m_configFileWatcher.addPath(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation));
+        configureWatcher();
     } else {
         m_configFileWatcher.removePaths(m_configFileWatcher.files() + m_configFileWatcher.directories());
     }
+}
+
+void Effect::configureWatcher()
+{
+    m_configFileWatcher.addPath(configFile);
+    m_configFileWatcher.addPath(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation));
 }

--- a/src/kwin/effect.h
+++ b/src/kwin/effect.h
@@ -23,6 +23,8 @@ private slots:
     void slotConfigDirectoryChanged();
 
 private:
+    void configureWatcher();
+
     bool m_autoReload = true;
     std::unique_ptr<GestureInputEventFilter> m_inputEventFilter = std::make_unique<GestureInputEventFilter>();
     QFileSystemWatcher m_configFileWatcher;


### PR DESCRIPTION
If the effect was loaded when the configuration file didn't exist, the file watcher wouldn't work.