### PR TITLE
kwin: add workaround for two-finger pinch gesture detection

### DIFF
--- a/src/kwin/inputfilter.h
+++ b/src/kwin/inputfilter.h
@@ -48,4 +48,6 @@ private:
     std::shared_ptr<libgestures::GestureRecognizer> m_touchpadGestureRecognizer = std::make_shared<libgestures::GestureRecognizer>();
     QTimer m_touchpadHoldGestureTimer;
     QTimer m_scrollTimer;
+
+    bool m_pinchGestureActive = false;
 };


### PR DESCRIPTION
Two-finger pinch gestures may be at first incorrectly interpreted by libinput as scrolling. Libinput does eventually correctly determine the gesture after a few events, but it doesn't send the GESTURE_PINCH_BEGIN event, which prevents the plugin from handling that gesture.

```
event16  GESTURE_HOLD_BEGIN          +109.982s 2
event16  GESTURE_HOLD_END            +110.007s 2 cancelled
event16  POINTER_SCROLL_FINGER       +110.007s vert -1.31/0.0* horiz -1.58/0.0* (finger)
event16  POINTER_SCROLL_FINGER     2 +110.015s vert 0.00/0.0* horiz 0.00/0.0* (finger)
event16  GESTURE_PINCH_UPDATE        +110.022s 2 -1.47/-1.23 (-1.58/-1.31 unaccelerated)  1.04 @  0.48
event16  GESTURE_PINCH_UPDATE      2 +110.030s 2 -1.47/-0.49 (-1.58/-0.53 unaccelerated)  1.08 @  0.47
event16  GESTURE_PINCH_UPDATE      3 +110.037s 2 -1.58/ 0.53 (-1.58/ 0.53 unaccelerated)  1.12 @  0.68
event16  GESTURE_PINCH_UPDATE      4 +110.044s 2 -1.58/ 1.58 (-1.58/ 1.58 unaccelerated)  1.16 @  0.67
event16  GESTURE_PINCH_UPDATE      5 +110.051s 2 -1.31/ 0.26 (-1.31/ 0.26 unaccelerated)  1.21 @  0.51
event16  GESTURE_PINCH_UPDATE      6 +110.059s 2 -1.31/ 0.26 (-1.31/ 0.26 unaccelerated)  1.25 @  0.44
event16  GESTURE_PINCH_UPDATE      7 +110.066s 2 -1.31/ 0.53 (-1.31/ 0.53 unaccelerated)  1.28 @  0.54
event16  GESTURE_PINCH_UPDATE      8 +110.073s 2 -1.58/ 0.26 (-1.58/ 0.26 unaccelerated)  1.32 @  0.42
event16  GESTURE_PINCH_UPDATE      9 +110.080s 2 -1.31/ 0.26 (-1.31/ 0.26 unaccelerated)  1.34 @  0.45
event16  GESTURE_PINCH_UPDATE     10 +110.088s 2 -1.84/ 0.53 (-1.84/ 0.53 unaccelerated)  1.38 @  0.45
event16  GESTURE_PINCH_UPDATE     11 +110.095s 2 -1.58/ 1.05 (-1.58/ 1.05 unaccelerated)  1.41 @  0.51
event16  GESTURE_PINCH_UPDATE     12 +110.103s 2 -1.58/ 0.53 (-1.58/ 0.53 unaccelerated)  1.44 @  0.49
event16  GESTURE_PINCH_UPDATE     13 +110.109s 2 -1.58/ 0.26 (-1.58/ 0.26 unaccelerated)  1.47 @  0.47
event16  GESTURE_PINCH_UPDATE     14 +110.117s 2 -1.05/ 0.53 (-1.05/ 0.53 unaccelerated)  1.49 @  0.41
event16  GESTURE_PINCH_END           +110.138s 2
```