### PR TITLE
libgestures/actions/command: execute in a separate thread

### DIFF
--- a/src/libgestures/libgestures/actions/command.cpp
+++ b/src/libgestures/libgestures/actions/command.cpp
@@ -1,5 +1,7 @@
 #include "command.h"
 
+#include <thread>
+
 namespace libgestures
 {
 
@@ -9,13 +11,16 @@ bool CommandGestureAction::tryExecute()
         return false;
     }
 
-    std::ignore = std::system(m_command.c_str());
+    std::thread thread([this]() {
+        std::system(m_command.c_str());
+    });
+    thread.detach();
     return true;
 }
 
 void CommandGestureAction::setCommand(const QString &command)
 {
-    m_command = (command + " &").toStdString();
+    m_command = command.toStdString();
 }
 
 }


### PR DESCRIPTION
Simply adding *&* to the end of the command won't work for multi-line ones. Commands can freeze the compositor and not even switching to a different tty will work.